### PR TITLE
Add reusable workflow for GitHub OIDC authentication with AWS

### DIFF
--- a/.github/oidc-auth-usage.md
+++ b/.github/oidc-auth-usage.md
@@ -12,7 +12,7 @@ jobs:
     uses: reportportal/.github/.github/workflows/aws-oidc-auth.yaml@main
     with:
       role_arn: ${{ secrets.AWS_ROLE_ARN }}
-      aws_region: us-east-1
+      aws_region: eu-central-1
 ```
 
 ## AWS IAM Role Requirements

--- a/.github/oidc-auth-usage.md
+++ b/.github/oidc-auth-usage.md
@@ -1,0 +1,61 @@
+# Using OIDC-based AWS Authentication in GitHub Actions
+
+This repository provides a reusable workflow to assume AWS IAM roles via GitHub OIDC federation.
+
+## Usage
+
+In your repository's workflow file, you can call the reusable workflow like this:
+
+```yaml
+jobs:
+  configure-aws:
+    uses: reportportal/.github/.github/workflows/aws-oidc-auth.yaml@main
+    with:
+      role_arn: ${{ secrets.AWS_ROLE_ARN }}
+      aws_region: us-east-1
+```
+
+## AWS IAM Role Requirements
+
+The IAM role must:
+
+- Trust the GitHub OIDC provider: `token.actions.githubusercontent.com`
+- Have a trust policy condition scoped to your specific repository and branch, for example:
+
+```json
+"Condition": {
+  "StringEquals": {
+    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+    "token.actions.githubusercontent.com:sub": "repo:reportportal/<your-repo>:ref:refs/heads/main"
+  }
+}
+```
+
+You can replace `refs/heads/main` with another branch reference if needed.
+
+## IAM Role Naming Convention
+
+Use a consistent and descriptive naming pattern for the IAM role, such as:
+
+```
+GitHubActions-reportportal-<environment>-<purpose>
+```
+
+Example:
+```
+GitHubActions-reportportal-prod-deploy
+```
+
+## AWS Identity Provider Setup
+
+Ensure that the GitHub OIDC identity provider has been added in the AWS account with the following settings:
+
+- Provider URL: `https://token.actions.githubusercontent.com`
+- Audience: `sts.amazonaws.com`
+- GitHub organization: `reportportal`
+- Repository and branch: `*` (or specify them for tighter security)
+
+## Reference
+
+Official AWS guide:  
+https://aws.amazon.com/blogs/security/use-iam-roles-to-connect-github-actions-to-actions-in-aws/

--- a/.github/workflows/aws-oidc-auth.yaml
+++ b/.github/workflows/aws-oidc-auth.yaml
@@ -1,0 +1,21 @@
+name: "Assume AWS Role via OIDC"
+on:
+  workflow_call:
+    inputs:
+      role_arn:
+        required: true
+        type: string
+      aws_region:
+        required: false
+        type: string
+        default: eu-central-1
+
+jobs:
+  configure:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ inputs.role_arn }}
+          aws-region: ${{ inputs.aws_region }}

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_GITHUB_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -1,7 +1,8 @@
 name: Build Docker image and push to AWS ECR
 
+
 on:
-  workflow_call:
+  workflow_call: 
     inputs:
       aws-region:
         description: 'AWS Region'
@@ -58,13 +59,11 @@ on:
         required: false
         type: string
         default: 'ubuntu-latest'
+      role-arn:
+        description: 'IAM Role ARN to assume via OIDC'
+        required: true
+        type: string
     secrets:
-      AWS_ACCESS_KEY_ID:
-        description: 'AWS Access Key ID'
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        description: 'AWS Secret Access Key'
-        required: true
       GH_USER:
         description: 'GitHub user'
         required: false
@@ -83,10 +82,14 @@ env:
   BRANCH: ${{ inputs.branch }}
   DATE: ${{ inputs.date }}
   RELEASE_MODE: ${{ inputs.release-mode }}
+
 jobs:
   build-and-export:
     name: Build and export to AWS ECR
     runs-on: ${{ inputs.runs-on }}
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -96,9 +99,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          # role-to-assume: arn:aws:iam::123456789012:role/my-github-actions-role
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ inputs.role-arn }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -106,10 +107,10 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
         with:
           mask-password: 'true'
-      
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -131,7 +132,7 @@ jobs:
           tags: |
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
             ${{ env.ADDITIONAL_TAG != '' && format('{0}/{1}:{2}', env.ECR_REGISTRY, env.ECR_REPOSITORY, env.ADDITIONAL_TAG) || '' }}
-            ${{ env.ADDITIONAL_TAG_2 != '' && format('{0}/{1}:{2}', env.ECR_REGISTRY, env.ECR_REPOSITORY, env.ADDITIONAL_TAG_2) || '' }}
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         if: ${{ inputs.scan-image }}
@@ -144,7 +145,7 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
-      
+
       - name: Summarize
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -152,5 +153,5 @@ jobs:
         run: |
           echo "## General information about the build:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- :gift: Docker image in Amazon ECR: $ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_STEP_SUMMARY
-          echo "- :octocat: The commit SHA from which the build was performed: [$GITHUB_SHA](https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA)" >> $GITHUB_STEP_SUMMARY
+          echo "- Docker image in Amazon ECR: $ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_STEP_SUMMARY
+          echo "- The commit SHA from which the build was performed: [$GITHUB_SHA](https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -59,10 +59,6 @@ on:
         required: false
         type: string
         default: 'ubuntu-latest'
-      role-arn:
-        description: 'IAM Role ARN to assume via OIDC'
-        required: true
-        type: string
     secrets:
       GH_USER:
         description: 'GitHub user'
@@ -99,7 +95,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: ${{ inputs.role-arn }}
+          role-to-assume: arn:aws:iam::334301710522:role/GitHubActions-reportportal-deploy
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::334301710522:role/GitHubActions-reportportal-deploy
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR


### PR DESCRIPTION
Implements a reusable GitHub Actions workflow (`aws-oidc-auth.yaml`) that allows any repository in the `reportportal` organization to assume an AWS IAM role via OIDC, without relying on long-lived access keys.

**Included:**

1. OIDC provider registered in AWS IAM
2. Shared IAM role (`GitHubActions-reportportal-deploy`) scoped to `repo:reportportal/*`
3. Reusable workflow under `.github/workflows/aws-oidc-auth.yaml`
4. Documentation file: `oidc-auth-usage.md`

**Usage**
Repos can call this workflow and pass the IAM role ARN:

```yaml
jobs:
  deploy:
    uses: reportportal/.github/.github/workflows/aws-oidc-auth.yaml@main
    with:
      role_arn: ${{ secrets.AWS_ROLE_ARN }}
      aws_region: eu-central-1```